### PR TITLE
Fixing path for corrupted data

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -1,1 +1,175 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Importing Data Using Pandas - Lab\n", "\n", "## Introduction\n", "\n", "In this lab, you'll get some practice with loading files with summary or metadata, and if you find that easy, the optional \"level up\" content covers loading data from a corrupted csv file!\n", "\n", "## Objectives\n", "You will be able to:\n", "\n", "- Use pandas to import data from a CSV and and an Excel spreadsheet  \n", "\n", "##  Loading Files with Summary or Meta Data\n", "\n", "Load either of the files `'Zipcode_Demos.csv'` or `'Zipcode_Demos.xlsx'`. What's going on with this dataset? Clean it up into a useable format and describe the nuances of how the data is currently formatted.\n", "\n", "All data files are stored in a folder titled `'Data'`."]}, {"cell_type": "code", "execution_count": 1, "metadata": {}, "outputs": [], "source": ["# Import pandas using the standard alias\n"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Import the file and print the first 5 rows\n", "df = None\n"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Print the last 5 rows of df\n"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# What is going on with this data set? Anything unusual?"]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Clean up the dataset\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Level Up (Optional) - Loading Corrupt CSV files\n", "\n", "Occasionally, you encounter some really ill-formatted data. One example of this can be data that has strings containing commas in a csv file. Under the standard protocol, when this occurs, one is supposed to use quotes to differentiate between the commas denoting fields and the commas within those fields themselves. For example, we could have a table like this:  \n", "\n", "`ReviewerID,Rating,N_reviews,Review,VenueID\n", "123456,4,137,This restaurant was pretty good, we had a great time.,98765`\n", "\n", "Which should be saved like this if it were a csv (to avoid confusion with the commas in the Review text):\n", "`\"ReviewerID\",\"Rating\",\"N_reviews\",\"Review\",\"VenueID\"\n", "\"123456\",\"4\",\"137\",\"This restaurant was pretty good, we had a great time.\",\"98765\"`\n", "\n", "Attempt to import the corrupt file, or at least a small preview of it. It is appropriately titled `'Yelp_Reviews_corrupt.csv'`. Investigate some of the intricacies of skipping rows to then pass over this error and comment on what you think is going on."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["# Hint: Here's a useful programming pattern to use\n", "try:\n", "    # Do something\n", "except Exception as e:\n", "    # Handle your exception e"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Summary\n", "\n", "Congratulations, you now practiced your Pandas-importing skills!"]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.3"}}, "nbformat": 4, "nbformat_minor": 2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Importing Data Using Pandas - Lab\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "In this lab, you'll get some practice with loading files with summary or metadata, and if you find that easy, the optional \"level up\" content covers loading data from a corrupted csv file!\n",
+    "\n",
+    "## Objectives\n",
+    "You will be able to:\n",
+    "\n",
+    "- Use pandas to import data from a CSV and and an Excel spreadsheet  \n",
+    "\n",
+    "##  Loading Files with Summary or Meta Data\n",
+    "\n",
+    "Load either of the files `'Zipcode_Demos.csv'` or `'Zipcode_Demos.xlsx'`. What's going on with this dataset? Clean it up into a useable format and describe the nuances of how the data is currently formatted.\n",
+    "\n",
+    "All data files are stored in a folder titled `'Data'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import pandas using the standard alias\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import the file and print the first 5 rows\n",
+    "df = None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the last 5 rows of df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is going on with this data set? Anything unusual?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up the dataset\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Level Up (Optional) - Loading Corrupt CSV files\n",
+    "\n",
+    "Occasionally, you encounter some really ill-formatted data. One example of this can be data that has strings containing commas in a csv file. Under the standard protocol, when this occurs, one is supposed to use quotes to differentiate between the commas denoting fields and the commas within those fields themselves. For example, we could have a table like this:  \n",
+    "\n",
+    "`ReviewerID,Rating,N_reviews,Review,VenueID\n",
+    "123456,4,137,This restaurant was pretty good, we had a great time.,98765`\n",
+    "\n",
+    "Which should be saved like this if it were a csv (to avoid confusion with the commas in the Review text):\n",
+    "`\"ReviewerID\",\"Rating\",\"N_reviews\",\"Review\",\"VenueID\"\n",
+    "\"123456\",\"4\",\"137\",\"This restaurant was pretty good, we had a great time.\",\"98765\"`\n",
+    "\n",
+    "Attempt to import the corrupt file, or at least a small preview of it. It is appropriately titled `'Yelp_Reviews_Corrupt.csv'`. Investigate some of the intricacies of skipping rows to then pass over this error and comment on what you think is going on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hint: Here's a useful programming pattern to use\n",
+    "try:\n",
+    "    # Do something\n",
+    "except Exception as e:\n",
+    "    # Handle your exception e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Congratulations, you now practiced your Pandas-importing skills!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The provided file name for the corrupted dataset is `'Yelp_Reviews_corrupt.csv'`

The correct file name for the corrupted dataset is` 'Yelp_Reviews_Corrupt.csv'`

I fixed this typo in the lab's notebook! After this has been merged, I'm happy to update the solution branch!